### PR TITLE
Add detailed forecast view and radar map

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This project is a small Flask application that shows the current time and weathe
 
 The server retrieves data from the Pirate Weather API and caches the response for ten minutes. JavaScript on the client polls the server once per minute so the clock stays accurate even if the device time drifts.
 A small Flask application that shows the current time and weather forecast.
+It now includes a detailed view with hourly forecasts and an embedded radar map.
 
 
 ## Setup
@@ -43,7 +44,8 @@ Visit `http://localhost:5000` in your browser.
 clock-weather-display/
 ├── app.py                # Flask server
 ├── templates/
-│   └── index.html        # HTML page served to the client
+│   ├── index.html        # Homepage
+│   └── detail.html       # Detailed hourly forecast with radar
 ├── static/
 │   ├── css/style.css     # Styles for light/dark/darker themes
 │   ├── js/theme.js       # Manual theme toggle logic
@@ -54,10 +56,11 @@ clock-weather-display/
 
 ### Server
 
-`app.py` exposes two routes:
+`app.py` exposes several routes:
 
 - `/` – renders `index.html` with current weather data embedded in the page.
 - `/api` – returns the same data in JSON format so the client can refresh without reloading.
+- `/day/<idx>` – detailed hourly forecast and radar map for the selected day.
 
 The `get_weather()` helper fetches forecast information from Pirate Weather. Results are cached for 10 minutes in the `_cache` dictionary to avoid unnecessary API calls. Each request recalculates the theme mode based on the current time of day:
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -120,3 +120,43 @@ body.darker {
 #themeToggle:hover {
     transform: scale(1.2);
 }
+
+/* DETAIL PAGE */
+.hourly-forecast {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    justify-content: center;
+    margin-top: 30px;
+}
+
+.hour-card {
+    background-color: rgba(255, 255, 255, 0.15);
+    border-radius: 12px;
+    padding: 10px;
+    width: 120px;
+    text-align: center;
+}
+
+.hour-time {
+    font-weight: bold;
+    margin-bottom: 5px;
+}
+
+.detail-button-row {
+    margin-top: 20px;
+}
+
+#detailButton {
+    display: inline-block;
+    padding: 10px 20px;
+    background-color: rgba(255, 255, 255, 0.3);
+    border-radius: 8px;
+    text-decoration: none;
+    color: inherit;
+    transition: background-color 0.3s;
+}
+
+#detailButton:hover {
+    background-color: rgba(255, 255, 255, 0.5);
+}

--- a/templates/detail.html
+++ b/templates/detail.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Detailed Forecast</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet" />
+    <script src="{{ url_for('static', filename='js/theme.js') }}" defer></script>
+</head>
+<body class="light">
+    <div class="container">
+        <h2>{{ forecast.day }}</h2>
+        <div class="hourly-forecast">
+            {% for h in forecast.hourly %}
+            <div class="hour-card">
+                <div class="hour-time">{{ h.time }}</div>
+                <img src="{{ url_for('static', filename='icons/' + h.icon + '.svg') }}" class="small-icon" alt="icon" />
+                <div class="hour-temp">{{ h.temperature }}°F</div>
+                <div class="hour-summary">{{ h.summary }}</div>
+            </div>
+            {% endfor %}
+        </div>
+        <div class="radar">
+            <iframe src="{{ radar_url }}" width="650" height="450" frameborder="0"></iframe>
+        </div>
+        <p><a href="{{ url_for('home') }}">Back</a></p>
+    </div>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,13 +26,16 @@
         <div class="forecast-row" id="forecastRow">
         {% if weather %}
             {% for day in weather.forecast %}
-            <div class="forecast-card">
+            <a href="{{ url_for('day_detail', idx=loop.index0) }}" class="forecast-card">
                 <div class="day">{{ day.day }}</div>
                 <img src="{{ url_for('static', filename='icons/' + day.icon + '.svg') }}" alt="icon" class="small-icon" />
                 <div class="temps">{{ day.high }}° / {{ day.low }}°</div>
-            </div>
+            </a>
             {% endfor %}
         {% endif %}
+        </div>
+        <div class="detail-button-row">
+            <a id="detailButton" href="{{ url_for('day_detail', idx=0) }}">Detailed Forecast</a>
         </div>
         {% else %}
         <p class="error">Weather data is currently unavailable.</p>


### PR DESCRIPTION
## Summary
- include hourly forecast data from Pirate Weather
- add new detailed view route and template with embedded Windy radar
- make forecast cards clickable and add "Detailed Forecast" button
- style new components
- document new route and features in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68561d28affc8326aefce283b1c5041e