### PR TITLE
Improve night theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ The `get_weather()` helper fetches forecast information from Pirate Weather. Res
 - **dark** – 7:00 PM to 10:59 PM
 - **darker** – 11:00 PM through 8:29 AM
 
+In the dark and darker modes the background is nearly black. During these hours
+the text is rendered in a soft green tone so the display remains readable while
+minimizing brightness at night.
+
 ### Client
 
 The client page (template `index.html`) loads two JavaScript files:

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -96,13 +96,18 @@ body.light {
 }
 
 body.dark {
-    background: linear-gradient(135deg, #434343, #222222);
-    color: #f0f0f0;
+    background: linear-gradient(135deg, #222222, #000000);
+    color: #90ee90;
 }
 
 body.darker {
-    background: linear-gradient(135deg, #111111, #000000);
-    color: #ffffff;
+    background: #000000;
+    color: #90ee90;
+}
+
+body.dark .container,
+body.darker .container {
+    background-color: rgba(0, 0, 0, 0.2);
 }
 
 #themeToggle {


### PR DESCRIPTION
## Summary
- darken the night theme CSS and switch text to a light green
- note the new darker display in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6860ba2781f88326b38a06100ab4b9ad